### PR TITLE
build: enable `-experimental-hermetic-seal-at-link`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ IMG := kernel8.img
 
 TRIPLE := aarch64-none-none-elf
 SWIFT := swift
+SWIFT_BUILD_FLAGS := --triple $(TRIPLE) -c release --experimental-lto-mode=full
 LD := clang -fuse-ld=lld
 LDFLAGS := -target $(TRIPLE) -nostdlib -Wl,-gc-sections -static
 OBJCOPY := llvm-objcopy
@@ -19,7 +20,7 @@ $(IMG): $(EXE)
 
 .PHONY: swift
 swift:
-	$(SWIFT) build --triple $(TRIPLE) -c release
+	$(SWIFT) build $(SWIFT_BUILD_FLAGS)
 
 .PHONY: run
 run: all

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
                 .unsafeFlags(["-Xfrontend", "-no-allocations"]),
                 .unsafeFlags(["-Xfrontend", "-function-sections"]),
                 .unsafeFlags(["-Xfrontend", "-disable-stack-protector"]),
+                .unsafeFlags(["-experimental-hermetic-seal-at-link"]),
                 .define("RASPI3"),
             ]
         ),


### PR DESCRIPTION
This option reduces binary sizes.

w/o `-experimental-hermetic-seal-at-link`:

```
-rwxr-xr-x. 1 kebo kebo   792 May  4 02:15 kernel8.img
-rwxr-xr-x. 1 kebo kebo 68168 May  4 02:15 kernel.elf
```

w/ `-experimental-hermetic-seal-at-link`:

```
-rwxr-xr-x. 1 kebo kebo   752 May  4 02:14 kernel8.img
-rwxr-xr-x. 1 kebo kebo 67392 May  4 02:14 kernel.elf
```