### PR TITLE
ci: do not overwrite builtin LLVM tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     container: swiftlang/swift:nightly-6.0-jammy
     steps:
       - uses: actions/checkout@v4
-      - run: apt-get update && apt-get install --no-install-recommends -y make llvm
-      - run: make
+      - run: apt-get update && apt-get install --no-install-recommends -y make llvm-14
+      - run: make OBJCOPY=llvm-objcopy-14
   lint:
     runs-on: ubuntu-latest
     container: swiftlang/swift:nightly-6.0-jammy


### PR DESCRIPTION
fixes #21

`llvm-14` installs LLVM tools with the `-14` suffix, so no conflicts occur.