### PR TITLE
build: pass swiftc the `-Osize` flag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
                 .unsafeFlags(["-Xfrontend", "-function-sections"]),
                 .unsafeFlags(["-Xfrontend", "-disable-stack-protector"]),
                 .unsafeFlags(["-experimental-hermetic-seal-at-link"]),
+                .unsafeFlags(["-Osize"]),
                 .define("RASPI3"),
             ]
         ),


### PR DESCRIPTION
This reduces binary sizes.

`-O` (default):

```
-rwxr-xr-x. 1 kebo kebo   752 May  4 03:34 kernel8.img
-rwxr-xr-x. 1 kebo kebo 67392 May  4 03:34 kernel.elf
```

`-Osize`:

```
-rwxr-xr-x. 1 kebo kebo   541 May  4 03:35 kernel8.img
-rwxr-xr-x. 1 kebo kebo 67208 May  4 03:35 kernel.elf
```

No flags are added to `cSettings` since `dymmy.c` and assembly files are not worth optimizing.