### PR TITLE
chore: replace deprecated PackageDescription API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,5 +29,5 @@ let package = Package(
         .target(name: "MailboxMessage"),
         .target(name: "Support"),
     ],
-    swiftLanguageVersions: [.v6]
+    swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
PackageDescription's `swiftLanguageVersions` is deprecated and replaced by `swiftLanguageModes`.

https://github.com/swiftlang/swift-evolution/blob/main/proposals/0441-formalize-language-mode-terminology.md