### PR TITLE
build: bump swift-tools-version to 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 
 import PackageDescription
 


### PR DESCRIPTION
swift_os requires Swift 6.1 toolchain because it's using the experimental feature `Volatile`. So there is no reason to support SwiftPM 6.0.