### PR TITLE
revert: fix: force to use `Framebuffer.shared` instead of an arbitary instance

### DIFF
--- a/Sources/Kernel/kmain.swift
+++ b/Sources/Kernel/kmain.swift
@@ -4,7 +4,8 @@ public func kmain() {
 
     print("Hello Swift!")
 
-    Framebuffer.shared.fillRect(x0: 0, y0: 0, x1: 100, y1: 100, color: 0xffffff)
+    let fb = Framebuffer()
+    fb.fillRect(x0: 0, y0: 0, x1: 100, y1: 100, color: 0xffffff)
 
     repeat { putchar(getchar()) } while true
 }


### PR DESCRIPTION
fixes #33 

This reverts commit f4d57f9b710de20c7cf04c8ab07e3af7c577a5c1.