### PR TITLE
refactor: add parameters to `Framebuffer.init`

### DIFF
--- a/Sources/Kernel/Framebuffer.swift
+++ b/Sources/Kernel/Framebuffer.swift
@@ -24,23 +24,35 @@ struct Framebuffer: ~Copyable {
     }
 
     // FIXME: it doesn't work on a real hardware
-    // static let shared = Self()
+    // static let shared = Self(
+    //     width: 1920,
+    //     height: 1080,
+    //     depth: 32,
+    //     pixelOrder: .rgb
+    // )
 
-    init() {
+    // FIXME: I don't know why, but if `init` is optimized, then the execution stops before reaching the last line.
+    @_optimize(none)
+    init(
+        width: UInt32,
+        height: UInt32,
+        depth: UInt32,
+        pixelOrder: PixelOrder
+    ) {
         mbox.0 = 35 * 4
         mbox.1 = 0  // request
 
         mbox.2 = MboxTag.setPhysicalWH
         mbox.3 = 8  // TODO: Understand what this is.
         mbox.4 = 0  // TODO: Understand what this is.
-        mbox.5 = 1920
-        mbox.6 = 1080
+        mbox.5 = width
+        mbox.6 = height
 
         mbox.7 = MboxTag.setVirtualWH
         mbox.8 = 8  // TODO: Understand what this is.
         mbox.9 = 8  // TODO: Understand what this is.
-        mbox.10 = 1920
-        mbox.11 = 1080
+        mbox.10 = width
+        mbox.11 = height
 
         mbox.12 = MboxTag.setVirtualOffset
         mbox.13 = 8  // TODO: Understand what this is.
@@ -51,12 +63,12 @@ struct Framebuffer: ~Copyable {
         mbox.17 = MboxTag.setDepth
         mbox.18 = 4  // TODO: Understand what this is.
         mbox.19 = 4  // TODO: Understand what this is.
-        mbox.20 = 32
+        mbox.20 = depth
 
         mbox.21 = MboxTag.setPixelOrder
         mbox.22 = 4  // TODO: Understand what this is.
         mbox.23 = 4  // TODO: Understand what this is.
-        mbox.24 = 1  // RGB
+        mbox.24 = pixelOrder.rawValue
 
         mbox.25 = MboxTag.allocateBuffer
         mbox.26 = 8  // TODO: Understand what this is.
@@ -73,7 +85,7 @@ struct Framebuffer: ~Copyable {
 
         guard
             mboxCall(ch: .property),  // success
-            mbox.20 == 32,  // depth
+            mbox.20 == depth,
             mbox.28 != 0  // pointer is not null
         else { fatalError() }
 

--- a/Sources/Kernel/kmain.swift
+++ b/Sources/Kernel/kmain.swift
@@ -4,7 +4,7 @@ public func kmain() {
 
     print("Hello Swift!")
 
-    let fb = Framebuffer()
+    let fb = Framebuffer(width: 1920, height: 1080, depth: 32, pixelOrder: .rgb)
     fb.fillRect(x0: 0, y0: 0, x1: 100, y1: 100, color: 0xffffff)
 
     repeat { putchar(getchar()) } while true


### PR DESCRIPTION
This helps avoid hard-coding constants.