### PR TITLE
ci: add `--parallel` to swift-format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
     container: swiftlang/swift:nightly-main-jammy
     steps:
       - uses: actions/checkout@v4
-      - run: swift format lint -rs .
+      - run: swift format lint -rsp .


### PR DESCRIPTION
This change makes the CI job faster.