### PR TITLE
fix: remove `@preconcurrency` from MailboxMessage

### DIFF
--- a/Sources/Kernel/Framebuffer.swift
+++ b/Sources/Kernel/Framebuffer.swift
@@ -1,4 +1,4 @@
-@preconcurrency import var MailboxMessage.mbox
+import var MailboxMessage.mbox
 
 enum PixelOrder: UInt32 {
     case bgr = 0

--- a/Sources/Kernel/mbox.swift
+++ b/Sources/Kernel/mbox.swift
@@ -1,4 +1,4 @@
-@preconcurrency import var MailboxMessage.mbox
+import var MailboxMessage.mbox
 
 let videocoreMbox = mmioBase + 0xB880
 let mboxRead = videocoreMbox

--- a/Sources/Kernel/uart.swift
+++ b/Sources/Kernel/uart.swift
@@ -1,7 +1,7 @@
 import Support
 
 #if RASPI4 || RASPI3
-    @preconcurrency import var MailboxMessage.mbox
+    import var MailboxMessage.mbox
 #endif
 
 #if RASPI4

--- a/Sources/MailboxMessage/include/mbox.h
+++ b/Sources/MailboxMessage/include/mbox.h
@@ -1,3 +1,4 @@
 #pragma once
 
+__attribute__((swift_attr("nonisolated(unsafe)")))
 volatile unsigned int __attribute__((aligned(16))) mbox[36];


### PR DESCRIPTION
According to [SE-0412](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0412-strict-concurrency-for-global-variables.md), there is `__attribute__((swift_attr("@MainActor")))` for C and Obj-C. However, there's no `MainActor` in Embedded Swift.

There are two options:

1. Wrapping `MailboxMessage.mbox` with a safer Swift type
2. Ignoring errors by appending `nonisolated(unsafe)` to `mbox`

Option 1 is ideal, but I'm going to work on #42 and `MailboxMessage.mbox` may be removed.

So I've decided to adopt option 2 for now. It can be achieved with `__attribute__((swift_attr("nonisolated(unsafe)")))`. swift_os's kernel is currently single-threaded, so it's safe.