### PR TITLE
build: add `--print-gc-sections` flag to linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SWIFT := swift
 SWIFT_BUILD_FLAGS := --triple $(TRIPLE) -c release -Xswiftc -Osize \
 					 --experimental-lto-mode=full -Xswiftc -experimental-hermetic-seal-at-link
 LD := clang -fuse-ld=lld
-LDFLAGS := --target=$(TRIPLE) -nostdlib -static -Xlinker --gc-sections
+LDFLAGS := --target=$(TRIPLE) -nostdlib -static -Wl,--gc-sections,--print-gc-sections
 OBJCOPY := llvm-objcopy
 QEMU := qemu-system-aarch64
 


### PR DESCRIPTION
With the `--print-gc-sections` flag, we can get the following outputs:

```
removing unused section .build/release/libKernel.a(boot.S.o):(.text)
removing unused section kernel.elf.lto.o:(.text)
```

These are useful for debugging because we can notice unexpected removing sections immediately.