### PR TITLE
build: reduce binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SWIFT := swift
 SWIFT_BUILD_FLAGS := --triple $(TRIPLE) -c release -Xswiftc -Osize \
 					 --experimental-lto-mode=full -Xswiftc -experimental-hermetic-seal-at-link
 LD := clang -fuse-ld=lld
-LDFLAGS := --target=$(TRIPLE) -nostdlib -static -Wl,--gc-sections,--print-gc-sections
+LDFLAGS := --target=$(TRIPLE) -nostdlib -static -Wl,--gc-sections,--print-gc-sections,--strip-all
 OBJCOPY := llvm-objcopy
 QEMU := qemu-system-aarch64
 


### PR DESCRIPTION
before

```
-rwxr-xr-x 1 kebo kebo  1636 Mar 10 20:28 kernel8.img
-rwxr-xr-x 1 kebo kebo 69064 Mar 10 20:28 kernel.elf
```

after

```
-rwxr-xr-x 1 kebo kebo  1636 Mar 10 20:32 kernel8.img
-rwxr-xr-x 1 kebo kebo 67536 Mar 10 20:32 kernel.elf
```