### PR TITLE
build: remove explicit language mode specification

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,5 +30,4 @@ let package = Package(
         .target(name: "MailboxMessage"),
         .target(name: "Support"),
     ],
-    swiftLanguageModes: [.v6],
 )


### PR DESCRIPTION
Swift tools version 6 uses Swift 6 language mode by default, so I don't need to specify language mode explicitly.