### PR TITLE
build: bump swift-tools-version to 6.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 


### PR DESCRIPTION
swift_os already requires Swift 6.2 or later, so this change has no risks.