### PR TITLE
refactor: non-copyable `Mbox`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SWIFT := swift
 SWIFT_BUILD_FLAGS := --triple $(TRIPLE) -c release -Xswiftc -Osize \
 					 --experimental-lto-mode=full -Xswiftc -experimental-hermetic-seal-at-link
 LD := clang -fuse-ld=lld
-LDFLAGS := --target=$(TRIPLE) -nostdlib -static -Wl,--gc-sections,--print-gc-sections,--strip-all
+LDFLAGS := --target=$(TRIPLE) -nostdlib -static -Wl,--gc-sections,--print-gc-sections,--strip-all,--allow-multiple-definition
 OBJCOPY := llvm-objcopy
 QEMU := qemu-system-aarch64
 

--- a/Package.swift
+++ b/Package.swift
@@ -35,12 +35,13 @@ let package = Package(
         ),
         .target(
             name: "RaspberryPi",
-            dependencies: ["Font", "AsmSupport"],
+            dependencies: ["Font", "Support", "AsmSupport"],
             swiftSettings: swiftSettings + [
                 .enableExperimentalFeature("Volatile")
             ],
         ),
         .target(name: "Font", swiftSettings: swiftSettings),
+        .target(name: "Support", swiftSettings: swiftSettings),
         .target(name: "AsmSupport"),
     ],
 )

--- a/Sources/RaspberryPi/mbox.swift
+++ b/Sources/RaspberryPi/mbox.swift
@@ -13,7 +13,7 @@ let mboxFull: UInt32 = 0x8000_0000
 let mboxEmpty: UInt32 = 0x4000_0000
 
 @_alignment(16)
-struct Mbox {
+struct Mbox: ~Copyable {
     var `0`: UInt32 = 0
     var `1`: UInt32 = 0
     var `2`: UInt32 = 0

--- a/Sources/Support/memset.swift
+++ b/Sources/Support/memset.swift
@@ -1,0 +1,13 @@
+@_silgen_name("memset")
+func memset(
+    _ dst: UnsafeMutableRawPointer,
+    _ val: CInt,
+    _ len: Int,
+) -> UnsafeMutableRawPointer {
+    let dst = unsafe dst.bindMemory(to: UInt8.self, capacity: len)
+    var span = unsafe MutableSpan(_unsafeStart: dst, count: len)
+    for i in span.indices {
+        span[i] = UInt8(truncatingIfNeeded: val)
+    }
+    return .init(dst)
+}

--- a/Sources/Support/memset.swift
+++ b/Sources/Support/memset.swift
@@ -1,3 +1,4 @@
+// swift-format-ignore-file
 @_silgen_name("memset")
 func memset(
     _ dst: UnsafeMutableRawPointer,


### PR DESCRIPTION
I made `Mbox` non-copyable to avoid unexpectedly copying the global variable `mbox`.

It seems that `~Copyable` requires `memset`. So I also added its implementation to the new `Support` module.

```console
$ clang -fuse-ld=lld --target=aarch64-none-none-elf -nostdlib -static -Wl,--gc-sections,--print-gc-sections,--strip-all,--allow-multiple-definition -T linker.ld -Xlinker -Map=kernel.map .build/release/libKernel.a -o kernel.elf
removing unused section .build/release/libKernel.a(boot.S.o):(.text)
removing unused section kernel.elf.lto.o:(.text)
removing unused section kernel.elf.lto.o:(.text.swift_beginAccess)
removing unused section kernel.elf.lto.o:(.text.swift_endAccess)
ld.lld: error: undefined symbol: memset
>>> referenced by <compiler-generated>:0 (/<compiler-generated>:0)
>>>               kernel.elf.lto.o:($es10swift_once9predicate2fn7contextySpySiG_ySvXCSvtF)
clang: error: ld.lld command failed with exit code 1 (use -v to see invocation)
```

The newly added linker flag `--allow-multiple-definition` is to avoid the following errors:

```
ld.lld: error: duplicate symbol: *
>>> defined in .build/release/libKernel.a(Kernel.swift.bc)
>>> defined in .build/release/libKernel.a(memset.swift.bc)
```

All of the duplicated functions are not used and will be stripped, so it's safe.