### PR TITLE
feat(RaspberryPi)!: use `MutableSpan` instead of a pointer

### DIFF
--- a/Sources/Kernel/Kernel.swift
+++ b/Sources/Kernel/Kernel.swift
@@ -11,7 +11,7 @@ struct Kernel {
 
             print("Hello Swift!")
 
-            let fb = Framebuffer<UInt32>(width: 1920, height: 1080, pixelOrder: .rgb)
+            var fb = Framebuffer<UInt32>(width: 1920, height: 1080, pixelOrder: .rgb)
             fb.fillRect(x0: 0, y0: 0, x1: 100, y1: 100, color: 0xffffff)
             fb.drawString("Hello Swift!", x: 0, y: 100, color: 0xffffff)
 


### PR DESCRIPTION
`MutableSpan` is safer than direct pointer operations.

[SE-0467: MutableSpan](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0467-MutableSpan.md)