### PR TITLE
chore: add `.swift-version`

### DIFF
--- a/.swift-version
+++ b/.swift-version
@@ -1,0 +1,1 @@
+main-snapshot

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ An operating system written in Swift.
   - You can easily install the toolchain using [Swiftly](https://www.swift.org/install/).
 
     ```shell
-    swiftly install main-snapshot
-    swiftly use main-snapshot
+    swiftly install
     ```
 
 ## Building


### PR DESCRIPTION
swiftly will install and use the toolchain written in `.swift-version`.