### PR TITLE
revert: style: ignore some files temporarily because of `unsafe` expressions

### DIFF
--- a/Sources/RaspberryPi/Framebuffer.swift
+++ b/Sources/RaspberryPi/Framebuffer.swift
@@ -1,4 +1,3 @@
-// swift-format-ignore-file
 import Font
 
 package enum PixelOrder: UInt32, BitwiseCopyable, Sendable {

--- a/Sources/RaspberryPi/mbox.swift
+++ b/Sources/RaspberryPi/mbox.swift
@@ -1,4 +1,3 @@
-// swift-format-ignore-file
 import _Volatile
 
 let videocoreMbox = mmioBase + 0xB880

--- a/Sources/RaspberryPi/uart.swift
+++ b/Sources/RaspberryPi/uart.swift
@@ -1,4 +1,3 @@
-// swift-format-ignore-file
 import AsmSupport
 import _Volatile
 


### PR DESCRIPTION
This reverts commit 72ef6e9f91f6a23e8ce35689dd5b052dc877029e.

blocker: https://github.com/swiftlang/swift-format/issues/977