### PR TITLE
build: improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 LIB := .build/release/libKernel.a
-EXE := kernel.elf
-IMG := kernel8.img
-MAP := kernel.map
+EXE := .build/kernel.elf
+IMG := .build/kernel8.img
+MAP := .build/kernel.map
 LINKER_SCRIPT := linker.ld
 
 TRIPLE := aarch64-none-none-elf
@@ -31,7 +31,6 @@ run: $(IMG)
 
 .PHONY: clean
 clean:
-	$(RM) $(EXE) $(IMG) $(MAP)
 	$(SWIFT) package clean
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LINKER_SCRIPT := linker.ld
 TRIPLE := aarch64-none-none-elf
 SWIFT := swift
 SWIFT_BUILD_FLAGS := --triple $(TRIPLE) -c release -Xswiftc -Osize \
-					 --experimental-lto-mode=full -Xswiftc -experimental-hermetic-seal-at-link
+                     --experimental-lto-mode=full -Xswiftc -experimental-hermetic-seal-at-link
 LD := clang -fuse-ld=lld
 LDFLAGS := --target=$(TRIPLE) -nostdlib -static -Wl,--gc-sections,--print-gc-sections,--strip-all
 OBJCOPY := llvm-objcopy


### PR DESCRIPTION
- specify dependencies of each target so that we no longer need to clean build unless the Swift toolchain version is changed
- use more variables so that we can easily change filenames
- put all outputs into `.build` so that `swift package clean` can clean everything
- fix indentation