### PR TITLE
build: use toolset.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,22 @@
-LIB := .build/release/libKernel.a
-EXE := .build/kernel.elf
+EXE := .build/release/Kernel
 IMG := .build/kernel8.img
-MAP := .build/kernel.map
+TOOLSET := toolset.json
 LINKER_SCRIPT := linker.ld
 
 TRIPLE := aarch64-none-none-elf
 SWIFT := swift
-SWIFT_BUILD_FLAGS := --triple $(TRIPLE) -c release -Xswiftc -Osize \
+SWIFT_BUILD_FLAGS := --triple $(TRIPLE) --toolset $(TOOLSET) -c release -Xswiftc -Osize \
                      --experimental-lto-mode=full -Xswiftc -experimental-hermetic-seal-at-link
-LD := clang -fuse-ld=lld
-LDFLAGS := --target=$(TRIPLE) -nostdlib -static -Wl,--gc-sections,--print-gc-sections,--strip-all
 OBJCOPY := llvm-objcopy
 QEMU := qemu-system-aarch64
 
 .PHONY: all
 all: $(IMG)
 
-$(EXE): Makefile $(LINKER_SCRIPT) $(LIB)
-	$(LD) $(LDFLAGS) -T $(LINKER_SCRIPT) -Xlinker -Map=$(MAP) $(LIB) -o $@
-
 $(IMG): Makefile $(EXE)
 	$(OBJCOPY) $(EXE) -O binary $@
 
-$(LIB): Makefile .swift-version Package.swift $(wildcard Package.resolved) Sources
+$(EXE): Makefile .swift-version $(TOOLSET) $(LINKER_SCRIPT) Package.swift $(wildcard Package.resolved) Sources
 	$(SWIFT) build $(SWIFT_BUILD_FLAGS)
 
 .PHONY: run

--- a/Package.swift
+++ b/Package.swift
@@ -3,19 +3,14 @@
 import PackageDescription
 
 let swiftSettings: [SwiftSetting] = [
-    .enableExperimentalFeature("Embedded"),
     .enableExperimentalFeature("LifetimeDependence"),
-    .unsafeFlags(["-Xfrontend", "-no-allocations"]),
-    .unsafeFlags(["-Xfrontend", "-function-sections"]),
-    .unsafeFlags(["-Xfrontend", "-disable-stack-protector"]),
-    .unsafeFlags(["-Xfrontend", "-mergeable-symbols"]),
     .unsafeFlags(["-strict-memory-safety"]),
 ]
 
 let package = Package(
     name: "swift_os",
     products: [
-        .library(name: "Kernel", type: .static, targets: ["Kernel"])
+        .executable(name: "Kernel", targets: ["Kernel"])
     ],
     traits: [
         .default(enabledTraits: ["RASPI4"]),
@@ -26,7 +21,7 @@ let package = Package(
         "RASPI",
     ],
     targets: [
-        .target(
+        .executableTarget(
             name: "Kernel",
             dependencies: [
                 "AsmSupport",

--- a/Sources/AsmSupport/aarch64/boot.S
+++ b/Sources/AsmSupport/aarch64/boot.S
@@ -26,7 +26,7 @@ _start:
     cbnz w2, 3b
 
     // jump to Swift code, should not return
-4:  bl main
+4:  bl Kernel_main
     // for failsafe, halt this core too
     b 1b
 

--- a/toolset.json
+++ b/toolset.json
@@ -1,0 +1,25 @@
+{
+    "schemaVersion": "1.0",
+    "swiftCompiler": {
+        "extraCLIOptions": [
+            "-enable-experimental-feature", "Embedded",
+            "-Xfrontend", "-no-allocations",
+            "-Xfrontend", "-function-sections",
+            "-Xfrontend", "-disable-stack-protector",
+            "-Xfrontend", "-mergeable-symbols",
+            "-Xclang-linker", "-nostdlib",
+            "-Xclang-linker", "-fuse-ld=lld",
+        ]
+    },
+    "linker": {
+        "extraCLIOptions": [
+            "-nostdlib",
+            "-static",
+            "--gc-sections",
+            "--print-gc-sections",
+            "--strip-all",
+            "-T", "linker.ld",
+            "-Map", ".build/kernel.map",
+        ]
+    }
+}


### PR DESCRIPTION
This allows SwiftPM to build a final product without an additional linker step. So now our Makefile is purely a task runner, not a build script. This also helps LSP support.