### PR TITLE
build: prohibit orphan sections

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -15,5 +15,8 @@ SECTIONS {
         *(.debug*)
         *(.eh_frame*)
     }
+    .symtab : { *(.symtab) }
+    .strtab : { *(.strtab) }
+    .shstrtab : { *(.shstrtab) }
 }
 __bss_size = (__bss_end - __bss_start) >> 3;

--- a/toolset.json
+++ b/toolset.json
@@ -18,6 +18,7 @@
             "--gc-sections",
             "--print-gc-sections",
             "--strip-all",
+            "--orphan-handling=error",
             "-T", "linker.ld",
             "-Map", ".build/kernel.map",
         ]


### PR DESCRIPTION
I changed `--orphan-section` from `place` (default) to `error`, and explicitly specified rules in a linker script.

This prevents from forgetting to change a linker script when it need to be changed.