### PR TITLE
chore: fix LSP

### DIFF
--- a/.sourcekit-lsp/config.json
+++ b/.sourcekit-lsp/config.json
@@ -1,0 +1,9 @@
+{
+    "swiftPM": {
+        "configuration": "release",
+        "triple": "aarch64-none-none-elf",
+        "swiftCompilerFlags": [
+            "-enable-experimental-feature", "Embedded",
+        ]
+    }
+}


### PR DESCRIPTION
Now we can jump to definitions and show documentations and auto completions using SourceKit-LSP.