### PR TITLE
build: discard `.swift_modhash` section

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -14,6 +14,7 @@ SECTIONS {
         *(.comment)
         *(.debug*)
         *(.eh_frame*)
+        *(.swift_modhash*)
     }
     .symtab : { *(.symtab) }
     .strtab : { *(.strtab) }


### PR DESCRIPTION
fixes #83 