### PR TITLE
build: remove `-mergeable-symbols`

### DIFF
--- a/toolset.json
+++ b/toolset.json
@@ -7,7 +7,6 @@
             "-Xfrontend", "-no-allocations",
             "-Xfrontend", "-function-sections",
             "-Xfrontend", "-disable-stack-protector",
-            "-Xfrontend", "-mergeable-symbols",
             "-Xclang-linker", "-nostdlib",
             "-Xclang-linker", "-fuse-ld=lld"
         ]


### PR DESCRIPTION
`-mergeable-symbols` is now the default behavior in Embedded Swift, so we don't need to add the flag manually.