### PR TITLE
revert: ci: remove deprecated --strict flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: swift --version
-      - run: swift format lint -rp .
+      - run: swift format lint -rsp .
   yamllint:
     runs-on: ubuntu-24.04-arm
     steps:

--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ swift format format -rip .
 Lint:
 
 ```shell
-swift format lint -rp .
+swift format lint -rsp .
 ```


### PR DESCRIPTION
This PR is intended to follow the swift-format's change: https://github.com/swiftlang/swift-format/pull/999.