### PR TITLE
style: partially re-enable lint

### DIFF
--- a/Sources/RaspberryPi/Framebuffer.swift
+++ b/Sources/RaspberryPi/Framebuffer.swift
@@ -1,4 +1,3 @@
-// swift-format-ignore-file
 import Font
 
 package enum PixelOrder: UInt32, BitwiseCopyable, Sendable {

--- a/Sources/RaspberryPi/Framebuffer.swift
+++ b/Sources/RaspberryPi/Framebuffer.swift
@@ -5,6 +5,8 @@ package enum PixelOrder: UInt32, BitwiseCopyable, Sendable {
     case rgb
 }
 
+// FIXME: Remove NoAssignmentInExpressions: https://github.com/swiftlang/swift-format/issues/977
+// swift-format-ignore: NoAssignmentInExpressions
 @_optimize(none)
 private func setFramebufferMbox(
     width: UInt32,
@@ -102,7 +104,8 @@ package struct Framebuffer<Depth: UnsignedInteger>: ~Copyable {
         self.pixelOrder = unsafe .init(rawValue: mbox.24)!
         // GPU address to ARM address
         let addr = UInt(gpuAddr & 0x3FFF_FFFF)
-        // swift-format-ignore: NeverForceUnwrap
+        // FIXME: Remove NoAssignmentInExpressions: https://github.com/swiftlang/swift-format/issues/977
+        // swift-format-ignore: NeverForceUnwrap, NoAssignmentInExpressions
         unsafe self.baseAddress = UnsafeMutableRawPointer(bitPattern: addr)!
             .bindMemory(to: Depth.self, capacity: pixelCount)
         self.pixelCount = pixelCount

--- a/Sources/RaspberryPi/mbox.swift
+++ b/Sources/RaspberryPi/mbox.swift
@@ -1,4 +1,3 @@
-// swift-format-ignore-file
 import _Volatile
 
 let videocoreMbox = mmioBase + 0xB880

--- a/Sources/RaspberryPi/uart.swift
+++ b/Sources/RaspberryPi/uart.swift
@@ -48,6 +48,8 @@ package func getchar() -> UInt8 {
 
 #if RASPI4 || RASPI3
     // set up clock to 3 MHz
+    // FIXME: Remove NoAssignmentInExpressions: https://github.com/swiftlang/swift-format/issues/977
+    // swift-format-ignore: NoAssignmentInExpressions
     @_optimize(none)
     private func setClockRateMbox() {
         unsafe mbox.0 = 9 * 4

--- a/Sources/RaspberryPi/uart.swift
+++ b/Sources/RaspberryPi/uart.swift
@@ -1,4 +1,3 @@
-// swift-format-ignore-file
 import AsmSupport
 import _Volatile
 


### PR DESCRIPTION
swift-format does not yet fully support `unsafe` expressions, but the only remaining problem is now `NoAssignmentInExpressions`.