### PR TITLE
build: pin Swift toolchain version to main-snapshot-2025-05-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble
+    container: swiftlang/swift:nightly-main-noble@sha256:e4f11eda505368dbdb7ef7db50fd6ef519a4e52b408d8728d383ef5a72dcd507  # main-snapshot-2025-05-12
     steps:
       - uses: actions/checkout@v4
       - run: swift --version

--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,1 @@
-main-snapshot
+main-snapshot-2025-05-12


### PR DESCRIPTION
To pass CI, we must keep using main-snapshot-2025-05-12 until #101 is resolved.
