### PR TITLE
revert: build: pin Swift toolchain version to main-snapshot-2025-05-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:e4f11eda505368dbdb7ef7db50fd6ef519a4e52b408d8728d383ef5a72dcd507  # main-snapshot-2025-05-12
+    container: swiftlang/swift:nightly-main-noble
     steps:
       - uses: actions/checkout@v4
       - run: swift --version

--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,1 @@
-main-snapshot-2025-05-12
+main-snapshot


### PR DESCRIPTION
Reverts kkebo/swift_os#106

The new toolchain has been released. It’s time to revert the workaround.