### PR TITLE
ci: remove a workaround for the gpg error due to gzip compression

### DIFF
--- a/scripts/ci-install-swift.sh
+++ b/scripts/ci-install-swift.sh
@@ -11,6 +11,4 @@ hash -r
 
 echo "PATH=$PATH" >> "$GITHUB_ENV" && echo "SWIFTLY_HOME_DIR=$SWIFTLY_HOME_DIR" >> "$GITHUB_ENV" && echo "SWIFTLY_BIN_DIR=$SWIFTLY_BIN_DIR" >> "$GITHUB_ENV" && echo "SWIFTLY_TOOLCHAINS_DIR=$SWIFTLY_TOOLCHAINS_DIR" >> "$GITHUB_ENV"
 
-curl --silent --retry 3 --location --fail --compressed https://swift.org/keys/all-keys.asc | gpg --import -
-
 swiftly install -y


### PR DESCRIPTION
This workaround no longer seems to be needed.