### PR TITLE
build: remove `CDecl` feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,6 @@ import PackageDescription
 
 let swiftSettings: [SwiftSetting] = [
     .enableExperimentalFeature("LifetimeDependence"),
-    .enableExperimentalFeature("CDecl"),
     .enableExperimentalFeature("InlineAlways"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),


### PR DESCRIPTION
`CDecl` is now stabilized. So we don't need the feature flag.