### PR TITLE
build: remove `InlineAlways` feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,6 @@ import PackageDescription
 
 let swiftSettings: [SwiftSetting] = [
     .enableExperimentalFeature("LifetimeDependence"),
-    .enableExperimentalFeature("InlineAlways"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
     .unsafeFlags(["-strict-memory-safety"]),


### PR DESCRIPTION
`InlineAlways` has been approved. So we don't need the feature flag.