### PR TITLE
feat: print memory size

### DIFF
--- a/Sources/Kernel/Kernel.swift
+++ b/Sources/Kernel/Kernel.swift
@@ -12,6 +12,11 @@ struct Kernel {
 
             print("Hello Swift!")
 
+            let memoryManager = MemoryManager()
+            print("RAM:", terminator: " ")
+            print(memoryManager.total / 1024 / 1024, terminator: " ")
+            print("MiB")
+
             var fb = Framebuffer<UInt32>(width: 1920, height: 1080, pixelOrder: .rgb)
             fb.fillRect(x0: 0, y0: 0, x1: 100, y1: 100, color: 0xffffff)
             fb.drawString("Hello Swift!", x: 0, y: 100, color: 0xffffff)

--- a/Sources/RaspberryPi/MemoryManager.swift
+++ b/Sources/RaspberryPi/MemoryManager.swift
@@ -1,0 +1,21 @@
+package struct MemoryManager {
+    /// Total physical memory size in bytes.
+    package let total: UInt
+
+    package init() {
+        unsafe mbox[0] = 8 * 4
+        unsafe mbox[1] = 0  // request
+
+        unsafe mbox[2] = MboxTag.getARMMemory
+        unsafe mbox[3] = 8  // TODO: Understand what this is.
+        unsafe mbox[4] = 8  // TODO: Understand what this is.
+        unsafe mbox[5] = 0
+        unsafe mbox[6] = 0
+
+        unsafe mbox[7] = MboxTag.end
+
+        guard mboxCall(ch: .property) else { fatalError() }
+
+        self.total = UInt(unsafe mbox[6])
+    }
+}

--- a/Sources/RaspberryPi/mbox.swift
+++ b/Sources/RaspberryPi/mbox.swift
@@ -45,6 +45,7 @@ enum MboxChannel: UInt8 {
 
 enum MboxTag {
     static let end: UInt32 = 0
+    static let getARMMemory: UInt32 = 0x0001_0005
     static let setClockRate: UInt32 = 0x0003_8002
     static let allocateBuffer: UInt32 = 0x0004_0001
     static let setPhysicalWH: UInt32 = 0x0004_8003


### PR DESCRIPTION
closes #85 

Future directions:

- The "Get ARM memory" mailbox interface returns only 1 GB.
  - https://github.com/raspberrypi/firmware/issues/1191#issuecomment-511838954
  - I will fix this in some time.
- Add more APIs to `MemoryManager` in #19.
- Print the physical memory size out to a display, not a serial port.
  - I'll work on this after implement malloc in #19.