### PR TITLE
Add support for development on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An operating system written in Swift.
 ## Prerequisites
 
 - QEMU 9.0 or later
+  - FreeBSD 15 or later: `doas pkg install qemu`
   - Arch Linux: `sudo pacman -S qemu-system-aarch64`
   - Fedora 41 or later: `sudo dnf install qemu-system-aarch64-core`
   - Fedora 40: Build from [source](https://www.qemu.org/download/#source)


### PR DESCRIPTION
Remaining blockers:

- [ ] FreeBSD toolchain doesn't include standard libraries for Embedded Swift
- [ ] Swiftly