### PR TITLE
build: add USB keyboard and USB mouse on QEMU

### DIFF
--- a/toolset.json
+++ b/toolset.json
@@ -28,6 +28,8 @@
             "qemu-system-aarch64",
             "-machine", "raspi4b",
             "-serial", "stdio",
+            "-device", "usb-mouse",
+            "-device", "usb-kbd",
             "-kernel"
         ]
     }


### PR DESCRIPTION
This is the preparation for the future work around GUI.

Relates to #45 