### PR TITLE
feat: add support for building in debug mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           restore-keys: ${{ runner.os }}-swiftpm-
       - run: ./scripts/ci-install-swift.sh
       - run: swift --version
-      - run: swift build -c release --triple aarch64-none-none-elf --toolset toolset.json --build-system native --explicit-target-dependency-import-check error
+      - run: swift build --triple aarch64-none-none-elf --toolset toolset.json --build-system native --explicit-target-dependency-import-check error
   build-macos:
     runs-on: macos-26
     permissions:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - run: ./scripts/ci-install-swift.sh
       - run: swift --version
-      - run: swift build -c release --triple aarch64-none-none-elf --toolset toolset.json --build-system native --explicit-target-dependency-import-check error
+      - run: swift build --triple aarch64-none-none-elf --toolset toolset.json --build-system native --explicit-target-dependency-import-check error
   lint:
     runs-on: ubuntu-24.04-arm
     permissions:

--- a/.sourcekit-lsp/config.json
+++ b/.sourcekit-lsp/config.json
@@ -1,6 +1,5 @@
 {
     "swiftPM": {
-        "configuration": "release",
         "triple": "aarch64-none-none-elf",
         "toolsets": ["toolset.json"]
     }

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ An operating system written in Swift.
 ## Building for emulators
 
 ```shell
-swift build -c release --triple aarch64-none-none-elf --toolset toolset.json --build-system native
+swift build --triple aarch64-none-none-elf --toolset toolset.json --build-system native
 ```
 
 ## Running on QEMU
 
 ```shell
-swift run -c release --triple aarch64-none-none-elf --toolset toolset.json --build-system native
+swift run --triple aarch64-none-none-elf --toolset toolset.json --build-system native
 ```
 
 ## Building for real hardwares
 
 ```shell
-swift build -c release --triple aarch64-none-none-elf --toolset toolset.json --build-system native
+swift build --triple aarch64-none-none-elf --toolset toolset.json --build-system native
 llvm-objcopy .build/release/Kernel -O binary .build/kernel8.img
 ```
 

--- a/Sources/Boot/aarch64/boot.S
+++ b/Sources/Boot/aarch64/boot.S
@@ -39,6 +39,9 @@ from_el2:
     adr x0, el1_entry
     msr elr_el2, x0
 
+    mov x0, xzr
+    msr cptr_el2, x0  // disable SIMD/FP traps
+
     isb
     eret
 
@@ -57,10 +60,18 @@ from_el3:
     adr x0, el1_entry
     msr elr_el3, x0
 
+    mov x0, xzr
+    msr cptr_el3, x0  // disable SIMD/FP traps
+
     isb
     eret
 
 el1_entry:
+    mrs x0, cpacr_el1
+    orr x0, x0, #(3 << 20)
+    msr cpacr_el1, x0  // enable SIMD/FP access
+    isb
+
     ldr x0, =__stack_top
     mov sp, x0
 

--- a/Sources/Hardware/Framebuffer.swift
+++ b/Sources/Hardware/Framebuffer.swift
@@ -12,9 +12,8 @@ package protocol Framebuffer: ~Copyable, ~Escapable, RenderTarget {
 
 extension Framebuffer where Self: ~Copyable {
     @unsafe
-    @inline(always)
-    @export(implementation)
     package subscript(uncheckedX x: Int, y y: Int) -> Depth {
+        @_transparent
         get {
             let x = UInt(x)
             let y = UInt(y)
@@ -22,6 +21,7 @@ extension Framebuffer where Self: ~Copyable {
             let stride = UInt(MemoryLayout<Depth>.stride)
             return unsafe Depth.volatileLoad(from: self.baseAddress &+ (y &* width &+ x) &* stride)
         }
+        @_transparent
         set(color) {
             let x = UInt(x)
             let y = UInt(y)

--- a/Sources/Kernel/Kernel.swift
+++ b/Sources/Kernel/Kernel.swift
@@ -16,7 +16,7 @@ struct Kernel {
         Self.mainLoop()
     }
 
-    @inline(always)
+    @_transparent
     private static func mainLoop() -> Never {
         zeroBSS()
 

--- a/Sources/LinkerSupport/ImageLayout.swift
+++ b/Sources/LinkerSupport/ImageLayout.swift
@@ -14,38 +14,31 @@ private nonisolated(unsafe) var stackEndHead: UInt8
 private nonisolated(unsafe) var kernelImageEndHead: UInt8
 
 package enum ImageLayout {
-    @inline(always)
-    @export(implementation)
+    @_transparent
     package static var kernelStart: UInt {
         unsafe withUnsafePointer(to: &kernelStartHead, UInt.init(bitPattern:))
     }
-    @inline(always)
-    @export(implementation)
+    @_transparent
     package static var kernelEnd: UInt {
         unsafe withUnsafePointer(to: &kernelEndHead, UInt.init(bitPattern:))
     }
-    @inline(always)
-    @export(implementation)
+    @_transparent
     package static var bssStart: UInt {
         unsafe withUnsafePointer(to: &bssStartHead, UInt.init(bitPattern:))
     }
-    @inline(always)
-    @export(implementation)
+    @_transparent
     package static var bssEnd: UInt {
         unsafe withUnsafePointer(to: &bssEndHead, UInt.init(bitPattern:))
     }
-    @inline(always)
-    @export(implementation)
+    @_transparent
     package static var stackStart: UInt {
         unsafe withUnsafePointer(to: &stackStartHead, UInt.init(bitPattern:))
     }
-    @inline(always)
-    @export(implementation)
+    @_transparent
     package static var stackEnd: UInt {
         unsafe withUnsafePointer(to: &stackEndHead, UInt.init(bitPattern:))
     }
-    @inline(always)
-    @export(implementation)
+    @_transparent
     package static var kernelImageEnd: UInt {
         unsafe withUnsafePointer(to: &kernelImageEndHead, UInt.init(bitPattern:))
     }

--- a/Sources/RaspberryPi/RPiFramebuffer.swift
+++ b/Sources/RaspberryPi/RPiFramebuffer.swift
@@ -11,6 +11,11 @@ package struct RPiFramebuffer<Depth: VolatileMappable>: ~Copyable, Framebuffer {
     /// Framebuffer base address.
     package let baseAddress: UInt
 
+    // FIXME: forces scalar lowering instead of SIMD (q0) load.
+    // Without this, Embedded Swift (main-snapshot-2026-06-12) may generate
+    // unsafe vectorized stack copies for this struct on AArch64 bare metal.
+    private let pad: UInt64 = 0
+
     package init(
         width: UInt32,
         height: UInt32,

--- a/Sources/RaspberryPi/UART0.swift
+++ b/Sources/RaspberryPi/UART0.swift
@@ -29,12 +29,12 @@ let uartCR = unsafe VolatileMappedRegister<UInt32>(unsafeBitPattern: uartBase + 
 let uartIMSC = unsafe VolatileMappedRegister<UInt32>(unsafeBitPattern: uartBase + 0x38)
 let uartICR = unsafe VolatileMappedRegister<UInt32>(unsafeBitPattern: uartBase + 0x44)
 
-@inline(always)
+@_transparent
 private func transmitFIFOFull() -> Bool {
     uartFR.load() & 1 << 5 > 0
 }
 
-@inline(always)
+@_transparent
 private func receiveFIFOEmpty() -> Bool {
     uartFR.load() & 1 << 4 > 0
 }

--- a/Sources/RaspberryPi/mbox.swift
+++ b/Sources/RaspberryPi/mbox.swift
@@ -17,15 +17,15 @@ struct Mbox: ~Copyable {
 
     init() {}
 
-    @inline(always)
+    @_transparent
     private mutating func volatilePointer(at i: Int) -> VolatileMappedRegister<UInt32> {
         unsafe .init(unsafeBitPattern: withUnsafePointer(to: &self.storage[i], UInt.init(bitPattern:)))
     }
 
-    @inline(always)
-    @export(implementation)
     subscript(_ i: Int) -> UInt32 {
+        @_transparent
         mutating get { self.volatilePointer(at: i).load() }
+        @_transparent
         set { self.volatilePointer(at: i).store(newValue) }
     }
 
@@ -68,12 +68,12 @@ enum MboxTag {
     static let setVirtualOffset: UInt32 = 0x0004_8009
 }
 
-@inline(always)
+@_transparent
 private func transmitMboxFull() -> Bool {
     mboxStatus.load() & mboxFull > 0
 }
 
-@inline(always)
+@_transparent
 private func receiveMboxEmpty() -> Bool {
     mboxStatus.load() & mboxEmpty > 0
 }

--- a/linker.ld
+++ b/linker.ld
@@ -33,5 +33,6 @@ SECTIONS {
         *(.debug*)
         *(.eh_frame*)
         *(.swift_modhash*)
+        *(.swift_ast)
     }
 }

--- a/toolset.json
+++ b/toolset.json
@@ -2,7 +2,6 @@
     "schemaVersion": "1.0",
     "swiftCompiler": {
         "extraCLIOptions": [
-            "-Osize",
             "-enable-experimental-feature", "Embedded",
             "-Xfrontend", "-no-allocations",
             "-Xfrontend", "-function-sections",


### PR DESCRIPTION
Changes:

- Removed the `-Osize` flag from toolchain.json
  - Instead, you can use `swift build ... -c release -Xswiftc -Osize` if you want to keep the binary size small.
- Replaced `@inline(always)` with `@_transparent` if it's appropriate
  - Unlike `@inline(always)`, `@_transparent` can eliminate function calls in debug mode too.
  - This is also a workaround for https://github.com/swiftlang/swift/issues/90106.
- Enabled SIMD/FP instructions
  - Swift compiler seems to generate SIMD instructions in debug mode.
- Added `*(.swift_ast)` to `/DISCARD/` in linker.ld
  - Swift compiler generates this section in debug mode.
  - I think it is not necessary at this time.
- Added a padding to `RPiFramebuffer`'s memory layout
  - This is a workaround for a runtime exception: `handleCurrentELSPxSync (ec = 37)`.
  - I'm going to investigate this in #165.
- Changed build instructions in README.md and CI to use debug mode by default
- Changed the build configuration from `release` to `debug` in `.sourcekit-lsp/config.json`
  - This fixes #163.

Notes:

- This PR unblocks #162.