### PR TITLE
perf: add `@export(implementation)` to `@_transparent` functions

### DIFF
--- a/Sources/ArchAArch64/SystemRegisters.swift
+++ b/Sources/ArchAArch64/SystemRegisters.swift
@@ -8,6 +8,7 @@ package struct CNTFRQ_EL0: BitwiseCopyable, Equatable, Hashable, Sendable {
     }
 
     @_transparent
+    @export(implementation)
     package static func read() -> Self { Self(rawValue: getCNTFRQ_EL0()) }
 }
 
@@ -19,6 +20,7 @@ package struct CNTPCT_EL0: BitwiseCopyable, Equatable, Hashable, Sendable {
     }
 
     @_transparent
+    @export(implementation)
     package static func read() -> Self { Self(rawValue: getCNTPCT_EL0()) }
 }
 
@@ -26,10 +28,13 @@ package struct CNTP_CTL_EL0: BitwiseCopyable, Equatable, Hashable, Sendable {
     private var rawValue: UInt64
 
     @_transparent
+    @export(implementation)
     package var enable: Bool { self.rawValue & 1 != 0 }
     @_transparent
+    @export(implementation)
     package var mask: Bool { self.rawValue >> 1 & 1 != 0 }
     @_transparent
+    @export(implementation)
     package var status: Bool { self.rawValue >> 2 & 1 != 0 }
 
     package init(rawValue: UInt64) {
@@ -37,6 +42,7 @@ package struct CNTP_CTL_EL0: BitwiseCopyable, Equatable, Hashable, Sendable {
     }
 
     @_transparent
+    @export(implementation)
     package static func read() -> Self { Self(rawValue: getCNTP_CTL_EL0()) }
 }
 
@@ -48,6 +54,7 @@ package struct CurrentEL: BitwiseCopyable, Equatable, Hashable, Sendable {
     }
 
     @_transparent
+    @export(implementation)
     package static func read() -> Self { Self(rawValue: getCurrentEL()) }
 }
 
@@ -55,32 +62,46 @@ package struct ID_AA64MMFR0_EL1: BitwiseCopyable, Equatable, Hashable, Sendable 
     private var rawValue: UInt64
 
     @_transparent
+    @export(implementation)
     package var paRange: UInt8 { UInt8(truncatingIfNeeded: self.rawValue & 0xf) }
     @_transparent
+    @export(implementation)
     package var asidBits: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 4 & 0xf) }
     @_transparent
+    @export(implementation)
     package var bigEnd: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 8 & 0xf) }
     @_transparent
+    @export(implementation)
     package var snsMem: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 12 & 0xf) }
     @_transparent
+    @export(implementation)
     package var bigEndEL0: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 16 & 0xf) }
     @_transparent
+    @export(implementation)
     package var tGran16: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 20 & 0xf) }
     @_transparent
+    @export(implementation)
     package var tGran64: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 24 & 0xf) }
     @_transparent
+    @export(implementation)
     package var tGran4: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 28 & 0xf) }
     @_transparent
+    @export(implementation)
     package var tGran16Stg2: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 32 & 0xf) }
     @_transparent
+    @export(implementation)
     package var tGran64Stg2: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 36 & 0xf) }
     @_transparent
+    @export(implementation)
     package var tGran4Stg2: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 40 & 0xf) }
     @_transparent
+    @export(implementation)
     package var exS: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 44 & 0xf) }
     @_transparent
+    @export(implementation)
     package var fgt: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 56 & 0xf) }
     @_transparent
+    @export(implementation)
     package var ecv: UInt8 { UInt8(truncatingIfNeeded: self.rawValue >> 60 & 0xf) }
 
     package init(rawValue: UInt64) {
@@ -88,5 +109,6 @@ package struct ID_AA64MMFR0_EL1: BitwiseCopyable, Equatable, Hashable, Sendable 
     }
 
     @_transparent
+    @export(implementation)
     package static func read() -> Self { Self(rawValue: getID_AA64MMFR0_EL1()) }
 }

--- a/Sources/Hardware/Framebuffer.swift
+++ b/Sources/Hardware/Framebuffer.swift
@@ -12,6 +12,7 @@ package protocol Framebuffer: ~Copyable, ~Escapable, RenderTarget {
 
 extension Framebuffer where Self: ~Copyable & ~Escapable {
     @unsafe
+    @export(implementation)
     package subscript(uncheckedX x: Int, y y: Int) -> Depth {
         @_transparent
         get {

--- a/Sources/KernelCore/Graphics.swift
+++ b/Sources/KernelCore/Graphics.swift
@@ -4,8 +4,10 @@ package struct Graphics<Target: RenderTarget & ~Copyable>: ~Copyable {
     var target: Target
 
     @_transparent
+    @export(implementation)
     package var width: Int { Int(self.target.width) }
     @_transparent
+    @export(implementation)
     package var height: Int { Int(self.target.height) }
 
     package init(target: consuming Target) {
@@ -18,6 +20,7 @@ package struct Graphics<Target: RenderTarget & ~Copyable>: ~Copyable {
     }
 
     @_transparent
+    @export(implementation)
     package mutating func fill(color: Target.Depth) {
         self.fillRect(x0: 0, y0: 0, x1: self.width - 1, y1: self.height - 1, color: color)
     }

--- a/Sources/KernelCore/UARTConsole.swift
+++ b/Sources/KernelCore/UARTConsole.swift
@@ -4,6 +4,7 @@ package struct UARTConsole<T: ~Copyable & UART>: ~Copyable {
     package let uart: T
 
     @_transparent
+    @export(implementation)
     package init(uart: consuming T) {
         self.uart = uart
     }
@@ -11,6 +12,7 @@ package struct UARTConsole<T: ~Copyable & UART>: ~Copyable {
 
 extension UARTConsole: Console where T: ~Copyable {
     @_transparent
+    @export(implementation)
     package func write(_ c: UInt8) {
         self.uart.putchar(c)
     }

--- a/Sources/RaspberryPi/UART0.swift
+++ b/Sources/RaspberryPi/UART0.swift
@@ -85,6 +85,7 @@ package struct UART0: ~Copyable {
 extension UART0: UART {
     /// Write a character to UART.
     @_transparent
+    @export(implementation)
     package func putchar(_ c: UInt8) {
         while transmitFIFOFull() {}
         uartDR.store(UInt32(c))
@@ -92,6 +93,7 @@ extension UART0: UART {
 
     /// Read a character from UART.
     @_transparent
+    @export(implementation)
     package func getchar() -> UInt8 {
         while receiveFIFOEmpty() {}
         return UInt8(uartDR.load())

--- a/Sources/RaspberryPi/mbox.swift
+++ b/Sources/RaspberryPi/mbox.swift
@@ -23,6 +23,7 @@ struct Mbox: ~Copyable {
         unsafe .init(unsafeBitPattern: withUnsafePointer(to: &self.storage[i], UInt.init(bitPattern:)))
     }
 
+    @export(implementation)
     subscript(_ i: Int) -> UInt32 {
         @_transparent
         mutating get { self.volatilePointer(at: i).load() }


### PR DESCRIPTION
This partially reverts PR #164.

Blockers:

- https://github.com/swiftlang/swift/issues/90225