### PR TITLE
fix: disable SIMD/FP to avoid Alignment Fault

### DIFF
--- a/Sources/Boot/aarch64/boot.S
+++ b/Sources/Boot/aarch64/boot.S
@@ -39,9 +39,6 @@ from_el2:
     adr x0, el1_entry
     msr elr_el2, x0
 
-    mov x0, xzr
-    msr cptr_el2, x0  // disable SIMD/FP traps
-
     isb
     eret
 
@@ -60,18 +57,10 @@ from_el3:
     adr x0, el1_entry
     msr elr_el3, x0
 
-    mov x0, xzr
-    msr cptr_el3, x0  // disable SIMD/FP traps
-
     isb
     eret
 
 el1_entry:
-    mrs x0, cpacr_el1
-    orr x0, x0, #(3 << 20)
-    msr cpacr_el1, x0  // enable SIMD/FP access
-    isb
-
     ldr x0, =__stack_top
     mov sp, x0
 

--- a/Sources/RaspberryPi/RPiFramebuffer.swift
+++ b/Sources/RaspberryPi/RPiFramebuffer.swift
@@ -11,13 +11,6 @@ package struct RPiFramebuffer<Depth: VolatileMappable>: ~Copyable, Framebuffer {
     /// Framebuffer base address.
     package let baseAddress: UInt
 
-    #if DEBUG
-        // FIXME: forces scalar lowering instead of SIMD (q0) load.
-        // Without this, Embedded Swift (main-snapshot-2026-06-12) may generate
-        // unsafe vectorized stack copies for this struct on AArch64 bare metal.
-        private let pad: UInt64 = 0
-    #endif
-
     package init(
         width: UInt32,
         height: UInt32,

--- a/toolset.json
+++ b/toolset.json
@@ -6,6 +6,7 @@
             "-Xfrontend", "-no-allocations",
             "-Xfrontend", "-function-sections",
             "-Xfrontend", "-disable-stack-protector",
+            "-Xcc", "-mgeneral-regs-only",
             "-Xlinker-driver", "-nostdlib",
             "-Xlinker-driver", "-fuse-ld=lld"
         ]


### PR DESCRIPTION
fixes #165

## Binary size comparison of `.build/debug/Kernel`:

### debug build:

- This PR: 117624
- main branch: 117624

(I verified that SHA256 sums of those two are different.)

### release build:

- This PR: 78888
- main branch: 78888

(I verified that SHA256 sums of those two are different.)