### PR TITLE
feat: add support for booting from EL1

### DIFF
--- a/Sources/Boot/aarch64/boot.S
+++ b/Sources/Boot/aarch64/boot.S
@@ -24,6 +24,9 @@ primary:
     cmp x0, #2
     b.eq from_el2
 
+    cmp x0, #1
+    b.eq el1_entry
+
     b hang
 
 from_el2:

--- a/Sources/Boot/aarch64/boot.S
+++ b/Sources/Boot/aarch64/boot.S
@@ -17,35 +17,11 @@ hang:
 primary:
     mrs x0, CurrentEL
     lsr x0, x0, #2
-
-    cmp x0, #3
-    b.eq from_el3
-
     cmp x0, #2
-    b.eq from_el2
+    b.eq el2_entry
+    b.lt el1_entry
 
-    cmp x0, #1
-    b.eq el1_entry
-
-    b hang
-
-from_el2:
-    mov x0, #(1 << 31)  // aarch64
-    msr hcr_el2, x0
-
-    msr cntvoff_el2, xzr
-
-    mov x0, #5  // EL1h
-    orr x0, x0, #(0xF << 6)  // mask DAIF
-    msr spsr_el2, x0  // set return level to EL1
-
-    adr x0, el1_entry
-    msr elr_el2, x0
-
-    isb
-    eret
-
-from_el3:
+el3_entry:
     mov x0, #(1 << 31)  // aarch64
     msr hcr_el2, x0
 
@@ -59,6 +35,22 @@ from_el3:
 
     adr x0, el1_entry
     msr elr_el3, x0
+
+    isb
+    eret
+
+el2_entry:
+    mov x0, #(1 << 31)  // aarch64
+    msr hcr_el2, x0
+
+    msr cntvoff_el2, xzr
+
+    mov x0, #5  // EL1 with SP_EL1 (EL1h)
+    orr x0, x0, #(0xF << 6)  // mask DAIF
+    msr spsr_el2, x0  // set return level to EL1
+
+    adr x0, el1_entry
+    msr elr_el2, x0
 
     isb
     eret


### PR DESCRIPTION
Currently, swift_os supports booting from EL3 or EL2. This change adds support for booting directly from EL1. This is useful in environments where the firmware or hypervisor has already transitioned to EL1 before entering the kernel, such as UEFI-based systems or virtual machines.

references:

- https://krinkinmu.github.io/2021/01/04/aarch64-exception-levels.html