### PR TITLE
fix: use raw pointer access to avoid memory rebinding

### DIFF
--- a/Sources/AppLibc/string.swift
+++ b/Sources/AppLibc/string.swift
@@ -6,11 +6,10 @@ public func memcpy(
     _ src: UnsafeRawPointer,
     _ n: Int,
 ) -> UnsafeMutableRawPointer {
-    let d = unsafe dst.bindMemory(to: UInt8.self, capacity: n)
-    let s = unsafe src.bindMemory(to: UInt8.self, capacity: n)
+    // TODO: copy word-by-word if possible
     var i = 0
     while i < n {
-        unsafe d[i] = s[i]
+        unsafe dst.storeBytes(of: src.load(fromByteOffset: i, as: UInt8.self), toByteOffset: i, as: UInt8.self)
         i &+= 1
     }
     return unsafe dst
@@ -24,19 +23,19 @@ public func memmove(
     _ src: UnsafeRawPointer,
     _ n: Int,
 ) -> UnsafeMutableRawPointer {
-    let d = unsafe dst.bindMemory(to: UInt8.self, capacity: n)
-    let s = unsafe src.bindMemory(to: UInt8.self, capacity: n)
     if unsafe dst < src {
+        // TODO: copy word-by-word if possible
         var i = 0
         while i < n {
-            unsafe d[i] = s[i]
+            unsafe dst.storeBytes(of: src.load(fromByteOffset: i, as: UInt8.self), toByteOffset: i, as: UInt8.self)
             i &+= 1
         }
     } else {
+        // TODO: copy word-by-word if possible
         var i = n
         while i > 0 {
             i &-= 1
-            unsafe d[i] = s[i]
+            unsafe dst.storeBytes(of: src.load(fromByteOffset: i, as: UInt8.self), toByteOffset: i, as: UInt8.self)
         }
     }
     return unsafe dst
@@ -50,10 +49,10 @@ public func memset(
     _ val: CInt,
     _ len: Int,
 ) -> UnsafeMutableRawPointer {
-    let d = unsafe dst.bindMemory(to: UInt8.self, capacity: len)
+    // TODO: copy word-by-word if possible
     var i = 0
     while i < len {
-        unsafe d[i] = UInt8(truncatingIfNeeded: val)
+        unsafe dst.storeBytes(of: UInt8(truncatingIfNeeded: val), toByteOffset: i, as: UInt8.self)
         i &+= 1
     }
     return unsafe dst

--- a/Sources/KernLibc/memcpy.swift
+++ b/Sources/KernLibc/memcpy.swift
@@ -6,11 +6,10 @@ public func memcpy(
     _ src: UnsafeRawPointer,
     _ n: Int,
 ) -> UnsafeMutableRawPointer {
-    let d = unsafe dst.bindMemory(to: UInt8.self, capacity: n)
-    let s = unsafe src.bindMemory(to: UInt8.self, capacity: n)
+    // TODO: copy word-by-word if possible
     var i = 0
     while i < n {
-        unsafe d[i] = s[i]
+        unsafe dst.storeBytes(of: src.load(fromByteOffset: i, as: UInt8.self), toByteOffset: i, as: UInt8.self)
         i &+= 1
     }
     return unsafe dst

--- a/Sources/KernLibc/memmove.swift
+++ b/Sources/KernLibc/memmove.swift
@@ -6,19 +6,19 @@ public func memmove(
     _ src: UnsafeRawPointer,
     _ n: Int,
 ) -> UnsafeMutableRawPointer {
-    let d = unsafe dst.bindMemory(to: UInt8.self, capacity: n)
-    let s = unsafe src.bindMemory(to: UInt8.self, capacity: n)
     if unsafe dst < src {
+        // TODO: copy word-by-word if possible
         var i = 0
         while i < n {
-            unsafe d[i] = s[i]
+            unsafe dst.storeBytes(of: src.load(fromByteOffset: i, as: UInt8.self), toByteOffset: i, as: UInt8.self)
             i &+= 1
         }
     } else {
+        // TODO: copy word-by-word if possible
         var i = n
         while i > 0 {
             i &-= 1
-            unsafe d[i] = s[i]
+            unsafe dst.storeBytes(of: src.load(fromByteOffset: i, as: UInt8.self), toByteOffset: i, as: UInt8.self)
         }
     }
     return unsafe dst

--- a/Sources/KernLibc/memset.swift
+++ b/Sources/KernLibc/memset.swift
@@ -6,10 +6,10 @@ public func memset(
     _ val: CInt,
     _ len: Int,
 ) -> UnsafeMutableRawPointer {
-    let d = unsafe dst.bindMemory(to: UInt8.self, capacity: len)
+    // TODO: copy word-by-word if possible
     var i = 0
     while i < len {
-        unsafe d[i] = UInt8(truncatingIfNeeded: val)
+        unsafe dst.storeBytes(of: UInt8(truncatingIfNeeded: val), toByteOffset: i, as: UInt8.self)
         i &+= 1
     }
     return unsafe dst


### PR DESCRIPTION
I replaced typed-pointer access with raw pointer access. This avoids
strict aliasing violations when copying memory whose binding is owned by
non-Swift code.
