### PR TITLE
feat: enable MMU

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,8 @@ let package = Package(
         .target(
             name: "ArchAArch64",
             dependencies: [
-                .target(name: "AsmSupport")
+                .target(name: "AsmSupport"),
+                .target(name: "LinkerSupport"),
             ],
             swiftSettings: swiftSettings,
         ),

--- a/Sources/ArchAArch64/MMU.swift
+++ b/Sources/ArchAArch64/MMU.swift
@@ -1,0 +1,85 @@
+private import AsmSupport
+private import LinkerSupport
+
+package func enableInitialMMU() {
+    // We cannot query the physical memory size before enabling the MMU.
+    // Use a fixed size for the initial memory mapping.
+    let initialDRAMSize: UInt = 1 << 30
+
+    let l2BlockSize: UInt = 1 << 21
+    precondition(initialDRAMSize.isMultiple(of: l2BlockSize), "Mapped RAM size must be 2 MiB aligned")
+
+    // Get physical addresses of L2 tables
+    let paddr0 = UInt(bitPattern: unsafe PageTable.l2Table0)
+    let paddr1 = UInt(bitPattern: unsafe PageTable.l2Table1)
+    let paddr2 = UInt(bitPattern: unsafe PageTable.l2Table2)
+    let paddr3 = UInt(bitPattern: unsafe PageTable.l2Table3)
+
+    // Set L1 entries pointing to L2 tables
+    unsafe PageTable.l1[0] = paddr0 | 3
+    unsafe PageTable.l1[1] = paddr1 | 3
+    unsafe PageTable.l1[2] = paddr2 | 3
+    unsafe PageTable.l1[3] = paddr3 | 3
+
+    // Populate L2 tables mapping the 4 GiB space block by block
+    for i in 0..<2048 {
+        let addr = UInt(i) * l2BlockSize
+        let (tableIndex, entryIndex) = i.quotientAndRemainder(dividingBy: 512)
+
+        // FIXME: The physical memory map is currently BCM2711-specific.
+        let descriptor =
+            switch addr {
+            case 0..<initialDRAMSize:
+                // DRAM -> Normal Non-Cacheable, Inner Shareable
+                // Lower attributes: AF=1, SH=3 (Inner Shareable), AP=0, AttrIndx=0
+                addr | 0x701
+            case 0xfc00_0000...0xffff_ffff:
+                // MMIO -> Device-nGnRnE
+                // Lower attributes: AF=1, SH=0, AP=0, AttrIndx=1
+                // Upper attributes: PXN=1, UXN=1
+                addr | 0x0060_0000_0000_0405
+            case _: 0 as UInt
+            }
+
+        switch tableIndex {
+        case 0: unsafe PageTable.l2Table0[entryIndex] = descriptor
+        case 1: unsafe PageTable.l2Table1[entryIndex] = descriptor
+        case 2: unsafe PageTable.l2Table2[entryIndex] = descriptor
+        case 3: unsafe PageTable.l2Table3[entryIndex] = descriptor
+        case _: preconditionFailure("unreachable")
+        }
+    }
+
+    let paRange = getMMFR0() & 0xf
+    let ips = tcrIPS(from: paRange)
+
+    enableMMU(
+        // MAIR_EL1:
+        // Index 0 = 0x44 (Normal Non-Cacheable)
+        // Index 1 = 0x00 (Device nGnRnE)
+        mair: 0x44 | (0x00 << 8),
+        // TCR_EL1:
+        // T0SZ = 25 (39-bit VA)
+        // EPD1 = 1 (Disable TTBR1 walks)
+        // TG0 = 0 (4 KiB granule)
+        // SH0 = 3 (Inner Shareable)
+        // ORGN0 = 1 (Outer WB WA cacheable)
+        // IRGN0 = 1 (Inner WB WA cacheable)
+        // IPS = paRange
+        tcr: (1 << 23) | (3 << 12) | (1 << 10) | (1 << 8) | 25 | (ips << 32),
+        ttbr0: UInt64(UInt(bitPattern: unsafe PageTable.l1)),
+    )
+}
+
+@_transparent
+private func tcrIPS(from paRange: UInt64) -> UInt64 {
+    switch paRange {
+    case 0b0000: 0b000  // 32-bit
+    case 0b0001: 0b001  // 36-bit
+    case 0b0010: 0b010  // 40-bit
+    case 0b0011: 0b011  // 42-bit
+    case 0b0100: 0b100  // 44-bit
+    case 0b0101: 0b101  // 48-bit
+    case _: preconditionFailure("unsupported PARange")
+    }
+}

--- a/Sources/AsmSupport/aarch64/asmfunc.S
+++ b/Sources/AsmSupport/aarch64/asmfunc.S
@@ -40,4 +40,30 @@ brk0:
     brk #0
     ret
 
+.global get_mmfr0
+get_mmfr0:
+    mrs x0, id_aa64mmfr0_el1
+    ret
+
+.global enable_mmu
+enable_mmu:
+    msr mair_el1, x0
+    msr tcr_el1, x1
+    msr ttbr0_el1, x2
+    isb
+
+    // Invalidate TLB and Instruction Cache (single core)
+    dsb sy
+    tlbi vmalle1
+    dsb sy
+    isb
+
+    mrs x3, sctlr_el1
+    orr x3, x3, #1          // M = 1 (MMU enable)
+    orr x3, x3, #(1 << 2)   // C = 1 (Data Cache enable)
+    orr x3, x3, #(1 << 12)  // I = 1 (Instruction Cache enable)
+    msr sctlr_el1, x3
+    isb
+    ret
+
 #endif

--- a/Sources/AsmSupport/include/AsmSupport.h
+++ b/Sources/AsmSupport/include/AsmSupport.h
@@ -14,4 +14,8 @@ uint32_t get_el(void);
 __attribute__((swift_name("registerVectorTable()")))
 void register_vector_table(void);
 void brk0(void);
+__attribute__((swift_name("getMMFR0()")))
+uint64_t get_mmfr0(void);
+__attribute__((swift_name("enableMMU(mair:tcr:ttbr0:)")))
+void enable_mmu(uint64_t mair, uint64_t tcr, uint64_t ttbr0);
 #endif

--- a/Sources/Kernel/Kernel.swift
+++ b/Sources/Kernel/Kernel.swift
@@ -20,6 +20,10 @@ struct Kernel {
     private static func mainLoop() -> Never {
         zeroBSS()
 
+        #if arch(arm64)
+            enableInitialMMU()
+        #endif
+
         #if RASPI
             let _ = UARTConsole(uart: UART0())
         #else

--- a/Sources/LinkerSupport/PageTable.swift
+++ b/Sources/LinkerSupport/PageTable.swift
@@ -1,0 +1,43 @@
+@_extern(c, "__l1_table")
+private nonisolated(unsafe) var l1TableHead: UInt8
+@_extern(c, "__l2_table_0")
+private nonisolated(unsafe) var l2Table0Head: UInt8
+@_extern(c, "__l2_table_1")
+private nonisolated(unsafe) var l2Table1Head: UInt8
+@_extern(c, "__l2_table_2")
+private nonisolated(unsafe) var l2Table2Head: UInt8
+@_extern(c, "__l2_table_3")
+private nonisolated(unsafe) var l2Table3Head: UInt8
+
+package enum PageTable {
+    @_transparent
+    package static var l1: UnsafeMutablePointer<UInt> {
+        unsafe withUnsafeMutablePointer(to: &l1TableHead) {
+            unsafe UnsafeMutableRawPointer($0).bindMemory(to: UInt.self, capacity: 512)
+        }
+    }
+    @_transparent
+    package static var l2Table0: UnsafeMutablePointer<UInt> {
+        unsafe withUnsafeMutablePointer(to: &l2Table0Head) {
+            unsafe UnsafeMutableRawPointer($0).bindMemory(to: UInt.self, capacity: 512)
+        }
+    }
+    @_transparent
+    package static var l2Table1: UnsafeMutablePointer<UInt> {
+        unsafe withUnsafeMutablePointer(to: &l2Table1Head) {
+            unsafe UnsafeMutableRawPointer($0).bindMemory(to: UInt.self, capacity: 512)
+        }
+    }
+    @_transparent
+    package static var l2Table2: UnsafeMutablePointer<UInt> {
+        unsafe withUnsafeMutablePointer(to: &l2Table2Head) {
+            unsafe UnsafeMutableRawPointer($0).bindMemory(to: UInt.self, capacity: 512)
+        }
+    }
+    @_transparent
+    package static var l2Table3: UnsafeMutablePointer<UInt> {
+        unsafe withUnsafeMutablePointer(to: &l2Table3Head) {
+            unsafe UnsafeMutableRawPointer($0).bindMemory(to: UInt.self, capacity: 512)
+        }
+    }
+}

--- a/linker.ld
+++ b/linker.ld
@@ -13,6 +13,19 @@ SECTIONS {
         __bss_start = .;
         *(.bss*)
         *(COMMON)
+
+        . = ALIGN(4096);
+        __l1_table = .;
+        . += 4096;
+        __l2_table_0 = .;
+        . += 4096;
+        __l2_table_1 = .;
+        . += 4096;
+        __l2_table_2 = .;
+        . += 4096;
+        __l2_table_3 = .;
+        . += 4096;
+
         . = ALIGN(8);
         __bss_end = .;
     }


### PR DESCRIPTION
resolves #183 
fixes #174 
fixes #187 

This is not a proper MMU setup, just an initial MMU setup.

- 4 KiB granule
- 39-bit virtual addresses (`T0SZ` = 25)
- `TTBR0` only (`TTBR0_EL1` -> L1 table -> L2 table)
- identity mapping (virtual address == physical address)
- DRAM -> Normal, Non-Cacheable, Inner Shareable memory
  - `0x0000_0000`-`<end of DRAM>` (`<end of DRAM>` is temporarily 1 GiB)
- MMIO -> Device-nGnRnE memory
  - `0xfc00_0000`-`0xffff_ffff`