### PR TITLE
feat: make DRAM cacheable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,8 +75,9 @@ let package = Package(
             name: "RaspberryPi",
             dependencies: [
                 .target(name: "Hardware"),
-                .target(name: "AsmSupport", condition: .when(traits: ["RASPI1", "RASPI2", "RASPI3"])),
+                .target(name: "AsmSupport"),
                 .target(name: "LinkerSupport"),
+                .target(name: "ArchAArch64"),
             ],
             swiftSettings: swiftSettings + [
                 .enableExperimentalFeature("Volatile")

--- a/Sources/ArchAArch64/MMU.swift
+++ b/Sources/ArchAArch64/MMU.swift
@@ -1,12 +1,12 @@
 private import AsmSupport
 private import LinkerSupport
 
-private let l2BlockSize: UInt = 1 << 21
-
 package func enableInitialMMU() {
     // We cannot query the physical memory size before enabling the MMU.
     // Use a fixed size for the initial memory mapping.
     let initialDRAMSize: UInt = 1 << 30
+
+    let l2BlockSize: UInt = 1 << 21
     precondition(initialDRAMSize.isMultiple(of: l2BlockSize), "Mapped RAM size must be 2 MiB aligned")
 
     // Get physical addresses of L2 tables
@@ -35,9 +35,9 @@ package func enableInitialMMU() {
                 addr | 0x701
             case 0xfc00_0000...0xffff_ffff:
                 // MMIO -> Device-nGnRnE
-                // Lower attributes: AF=1, SH=0, AP=0, AttrIndx=2
+                // Lower attributes: AF=1, SH=0, AP=0, AttrIndx=1
                 // Upper attributes: PXN=1, UXN=1
-                addr | 0x0060_0000_0000_0409
+                addr | 0x0060_0000_0000_0405
             case _: 0 as UInt
             }
 
@@ -56,9 +56,8 @@ package func enableInitialMMU() {
     enableMMU(
         // MAIR_EL1:
         // Index 0 = 0xFF (Normal Write-Back Cacheable)
-        // Index 1 = 0x44 (Normal Non-Cacheable)
-        // Index 2 = 0x00 (Device nGnRnE)
-        mair: 0xFF | (0x44 << 8) | (0x00 << 16),
+        // Index 1 = 0x00 (Device nGnRnE)
+        mair: 0xFF | (0x00 << 8),
         // TCR_EL1:
         // T0SZ = 25 (39-bit VA)
         // EPD1 = 1 (Disable TTBR1 walks)
@@ -83,35 +82,4 @@ private func tcrIPS(from paRange: UInt64) -> UInt64 {
     case 0b0101: 0b101  // 48-bit
     case _: preconditionFailure("unsupported PARange")
     }
-}
-
-package func setMemoryAttribute(physicalAddress: UInt, size: UInt, attrIndex: UInt) {
-    let startBlock = Int(physicalAddress / l2BlockSize)
-    let endBlock = Int((physicalAddress &+ size &- 1) / l2BlockSize &+ 1)
-
-    let attrIndexMask: UInt = 0b111 << 2
-    for i in startBlock..<endBlock {
-        let (tableIndex, entryIndex) = i.quotientAndRemainder(dividingBy: 512)
-
-        let table =
-            switch tableIndex {
-            case 0: unsafe PageTable.l2Table0
-            case 1: unsafe PageTable.l2Table1
-            case 2: unsafe PageTable.l2Table2
-            case 3: unsafe PageTable.l2Table3
-            case _: preconditionFailure("unreachable")
-            }
-
-        var descriptor = unsafe table[entryIndex]
-        descriptor &= ~attrIndexMask
-        descriptor |= (attrIndex << 2) & attrIndexMask
-        unsafe table[entryIndex] = descriptor
-    }
-
-    let pageTableSize = 512 * MemoryLayout<UInt>.stride
-    cleanDCache(start: unsafe UInt(bitPattern: PageTable.l2Table0), size: pageTableSize)
-    cleanDCache(start: unsafe UInt(bitPattern: PageTable.l2Table1), size: pageTableSize)
-    cleanDCache(start: unsafe UInt(bitPattern: PageTable.l2Table2), size: pageTableSize)
-    cleanDCache(start: unsafe UInt(bitPattern: PageTable.l2Table3), size: pageTableSize)
-    invalidateTLB()
 }

--- a/Sources/ArchAArch64/MMU.swift
+++ b/Sources/ArchAArch64/MMU.swift
@@ -1,12 +1,12 @@
 private import AsmSupport
 private import LinkerSupport
 
+private let l2BlockSize: UInt = 1 << 21
+
 package func enableInitialMMU() {
     // We cannot query the physical memory size before enabling the MMU.
     // Use a fixed size for the initial memory mapping.
     let initialDRAMSize: UInt = 1 << 30
-
-    let l2BlockSize: UInt = 1 << 21
     precondition(initialDRAMSize.isMultiple(of: l2BlockSize), "Mapped RAM size must be 2 MiB aligned")
 
     // Get physical addresses of L2 tables
@@ -30,14 +30,14 @@ package func enableInitialMMU() {
         let descriptor =
             switch addr {
             case 0..<initialDRAMSize:
-                // DRAM -> Normal Non-Cacheable, Inner Shareable
+                // DRAM -> Normal Write-Back Cacheable, Inner Shareable
                 // Lower attributes: AF=1, SH=3 (Inner Shareable), AP=0, AttrIndx=0
                 addr | 0x701
             case 0xfc00_0000...0xffff_ffff:
                 // MMIO -> Device-nGnRnE
-                // Lower attributes: AF=1, SH=0, AP=0, AttrIndx=1
+                // Lower attributes: AF=1, SH=0, AP=0, AttrIndx=2
                 // Upper attributes: PXN=1, UXN=1
-                addr | 0x0060_0000_0000_0405
+                addr | 0x0060_0000_0000_0409
             case _: 0 as UInt
             }
 
@@ -55,9 +55,10 @@ package func enableInitialMMU() {
 
     enableMMU(
         // MAIR_EL1:
-        // Index 0 = 0x44 (Normal Non-Cacheable)
-        // Index 1 = 0x00 (Device nGnRnE)
-        mair: 0x44 | (0x00 << 8),
+        // Index 0 = 0xFF (Normal Write-Back Cacheable)
+        // Index 1 = 0x44 (Normal Non-Cacheable)
+        // Index 2 = 0x00 (Device nGnRnE)
+        mair: 0xFF | (0x44 << 8) | (0x00 << 16),
         // TCR_EL1:
         // T0SZ = 25 (39-bit VA)
         // EPD1 = 1 (Disable TTBR1 walks)
@@ -82,4 +83,35 @@ private func tcrIPS(from paRange: UInt64) -> UInt64 {
     case 0b0101: 0b101  // 48-bit
     case _: preconditionFailure("unsupported PARange")
     }
+}
+
+package func setMemoryAttribute(physicalAddress: UInt, size: UInt, attrIndex: UInt) {
+    let startBlock = Int(physicalAddress / l2BlockSize)
+    let endBlock = Int((physicalAddress &+ size &- 1) / l2BlockSize &+ 1)
+
+    let attrIndexMask: UInt = 0b111 << 2
+    for i in startBlock..<endBlock {
+        let (tableIndex, entryIndex) = i.quotientAndRemainder(dividingBy: 512)
+
+        let table =
+            switch tableIndex {
+            case 0: unsafe PageTable.l2Table0
+            case 1: unsafe PageTable.l2Table1
+            case 2: unsafe PageTable.l2Table2
+            case 3: unsafe PageTable.l2Table3
+            case _: preconditionFailure("unreachable")
+            }
+
+        var descriptor = unsafe table[entryIndex]
+        descriptor &= ~attrIndexMask
+        descriptor |= (attrIndex << 2) & attrIndexMask
+        unsafe table[entryIndex] = descriptor
+    }
+
+    let pageTableSize = 512 * MemoryLayout<UInt>.stride
+    cleanDCache(start: unsafe UInt(bitPattern: PageTable.l2Table0), size: pageTableSize)
+    cleanDCache(start: unsafe UInt(bitPattern: PageTable.l2Table1), size: pageTableSize)
+    cleanDCache(start: unsafe UInt(bitPattern: PageTable.l2Table2), size: pageTableSize)
+    cleanDCache(start: unsafe UInt(bitPattern: PageTable.l2Table3), size: pageTableSize)
+    invalidateTLB()
 }

--- a/Sources/AsmSupport/aarch64/asmfunc.S
+++ b/Sources/AsmSupport/aarch64/asmfunc.S
@@ -21,6 +21,42 @@ disable_irq:
     msr daifset, #2
     ret
 
+.global invalidate_tlb
+invalidate_tlb:
+    dsb sy
+    tlbi vmalle1is
+    dsb sy
+    isb
+    ret
+
+.macro DCACHE_RANGE op
+    cbz x1, 2f
+    add x1, x0, x1
+    mrs x2, ctr_el0
+    lsr x2, x2, #16
+    and x2, x2, #0xf
+    mov x3, #4
+    lsl x3, x3, x2
+    sub x4, x3, #1
+    bic x0, x0, x4
+1:
+    dc \op, x0
+    add x0, x0, x3
+    cmp x0, x1
+    b.lo 1b
+    dsb ish
+2:
+    ret
+.endm
+
+.global clean_dcache_range
+clean_dcache_range:
+    DCACHE_RANGE cvac
+
+.global invalidate_dcache_range
+invalidate_dcache_range:
+    DCACHE_RANGE ivac
+
 .global get_el
 get_el:
     mrs x0, CurrentEL
@@ -52,9 +88,8 @@ enable_mmu:
     msr ttbr0_el1, x2
     isb
 
-    // Invalidate TLB (single core)
     dsb sy
-    tlbi vmalle1
+    tlbi vmalle1is
     dsb sy
     isb
 

--- a/Sources/AsmSupport/aarch64/asmfunc.S
+++ b/Sources/AsmSupport/aarch64/asmfunc.S
@@ -21,14 +21,6 @@ disable_irq:
     msr daifset, #2
     ret
 
-.global invalidate_tlb
-invalidate_tlb:
-    dsb sy
-    tlbi vmalle1is
-    dsb sy
-    isb
-    ret
-
 .macro DCACHE_RANGE op
     cbz x1, 2f
     add x1, x0, x1
@@ -88,8 +80,9 @@ enable_mmu:
     msr ttbr0_el1, x2
     isb
 
+    // Invalidate TLB (single core)
     dsb sy
-    tlbi vmalle1is
+    tlbi vmalle1
     dsb sy
     isb
 

--- a/Sources/AsmSupport/include/AsmSupport.h
+++ b/Sources/AsmSupport/include/AsmSupport.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 void delay(uint64_t);
@@ -8,6 +9,14 @@ __attribute__((swift_name("enableIRQ()")))
 void enable_irq(void);
 __attribute__((swift_name("disableIRQ()")))
 void disable_irq(void);
+__attribute__((swift_name("invalidateTLB()")))
+void invalidate_tlb(void);
+#ifndef __x86_64__
+__attribute__((swift_name("cleanDCache(start:size:)")))
+void clean_dcache_range(uintptr_t start, size_t size);
+__attribute__((swift_name("invalidateDCache(start:size:)")))
+void invalidate_dcache_range(uintptr_t start, size_t size);
+#endif
 #ifdef __aarch64__
 __attribute__((swift_name("getEL()")))
 uint32_t get_el(void);

--- a/Sources/AsmSupport/include/AsmSupport.h
+++ b/Sources/AsmSupport/include/AsmSupport.h
@@ -9,8 +9,6 @@ __attribute__((swift_name("enableIRQ()")))
 void enable_irq(void);
 __attribute__((swift_name("disableIRQ()")))
 void disable_irq(void);
-__attribute__((swift_name("invalidateTLB()")))
-void invalidate_tlb(void);
 #ifndef __x86_64__
 __attribute__((swift_name("cleanDCache(start:size:)")))
 void clean_dcache_range(uintptr_t start, size_t size);

--- a/Sources/Hardware/RenderTarget.swift
+++ b/Sources/Hardware/RenderTarget.swift
@@ -6,4 +6,6 @@ package protocol RenderTarget<Depth>: ~Copyable, ~Escapable {
 
     @unsafe
     subscript(uncheckedX x: Int, y y: Int) -> Depth { get set }
+
+    func synchronize()
 }

--- a/Sources/Kernel/Kernel.swift
+++ b/Sources/Kernel/Kernel.swift
@@ -77,6 +77,8 @@ struct Kernel {
             g.drawString(el, x: (elLabel.utf8CodeUnitCount + 1) * fontWidth, y: 2 * fontHeight, color: accent)
         #endif
 
+        g.synchronize()
+
         repeat { halt() } while true
     }
 }

--- a/Sources/KernelCore/Graphics.swift
+++ b/Sources/KernelCore/Graphics.swift
@@ -63,4 +63,8 @@ package struct Graphics<Target: RenderTarget & ~Copyable>: ~Copyable {
             self.drawChar(c, x: x &+ i * fontWidth, y: y, color: color)
         }
     }
+
+    package func synchronize() {
+        self.target.synchronize()
+    }
 }

--- a/Sources/RaspberryPi/RPiFramebuffer.swift
+++ b/Sources/RaspberryPi/RPiFramebuffer.swift
@@ -1,8 +1,5 @@
+private import AsmSupport
 package import Hardware
-
-#if arch(arm64)
-    private import ArchAArch64
-#endif
 
 @safe
 package struct RPiFramebuffer<Depth: VolatileMappable>: ~Copyable, Framebuffer {
@@ -14,6 +11,7 @@ package struct RPiFramebuffer<Depth: VolatileMappable>: ~Copyable, Framebuffer {
     package let pixelOrder: PixelOrder
     /// Framebuffer base address.
     package let baseAddress: UInt
+    private let byteCount: Int
 
     package init(
         width: UInt32,
@@ -84,11 +82,12 @@ package struct RPiFramebuffer<Depth: VolatileMappable>: ~Copyable, Framebuffer {
         self.pixelOrder = unsafe .init(rawValue: mbox[24])!
         // GPU address to ARM address
         self.baseAddress = UInt(gpuAddr & 0x3FFF_FFFF)
-
-        #if arch(arm64)
-            setMemoryAttribute(physicalAddress: self.baseAddress, size: UInt(byteCount), attrIndex: 1)
-        #endif
+        self.byteCount = Int(byteCount)
 
         print("Framebuffer is ready")
+    }
+
+    package func synchronize() {
+        cleanDCache(start: self.baseAddress, size: self.byteCount)
     }
 }

--- a/Sources/RaspberryPi/RPiFramebuffer.swift
+++ b/Sources/RaspberryPi/RPiFramebuffer.swift
@@ -1,5 +1,9 @@
 package import Hardware
 
+#if arch(arm64)
+    private import ArchAArch64
+#endif
+
 @safe
 package struct RPiFramebuffer<Depth: VolatileMappable>: ~Copyable, Framebuffer {
     /// Actual physical width.
@@ -80,6 +84,10 @@ package struct RPiFramebuffer<Depth: VolatileMappable>: ~Copyable, Framebuffer {
         self.pixelOrder = unsafe .init(rawValue: mbox[24])!
         // GPU address to ARM address
         self.baseAddress = UInt(gpuAddr & 0x3FFF_FFFF)
+
+        #if arch(arm64)
+            setMemoryAttribute(physicalAddress: self.baseAddress, size: UInt(byteCount), attrIndex: 1)
+        #endif
 
         print("Framebuffer is ready")
     }

--- a/Sources/RaspberryPi/mbox.swift
+++ b/Sources/RaspberryPi/mbox.swift
@@ -1,3 +1,4 @@
+private import AsmSupport
 import _Volatile
 
 let videocoreMbox = mmioBase + 0xB880
@@ -30,13 +31,20 @@ struct Mbox: ~Copyable {
     }
 
     mutating func call(ch: MboxChannel) -> Bool {
-        let addr = UInt32(withUnsafePointer(to: &self.storage, UInt.init(bitPattern:)))
-        let r = addr & ~0xF | UInt32(ch.rawValue & 0xF)
+        let addr = UInt(withUnsafePointer(to: &self, UInt.init(bitPattern:)))
+        let size = MemoryLayout.size(ofValue: self)
+
+        cleanDCache(start: addr, size: size)
+
+        let r = UInt32(addr) & ~0xF | UInt32(ch.rawValue & 0xF)
         while transmitMboxFull() {}
         mboxWrite.store(r)
         repeat {
             while receiveMboxEmpty() {}
         } while mboxRead.load() != r
+
+        invalidateDCache(start: addr, size: size)
+
         return self[1] == mboxResponse
     }
 }


### PR DESCRIPTION
fixes #167 

## Why does this fix #167?

- Global `InlineArray` constants are initialized using `swift_once`.
- `swift_once` uses AArch64 exclusive accesses (LDAXR/STLXR).
- The BCM2711 memory system appears not to handle exclusive accesses to Normal Non-Cacheable memory as expected.

## Changes

- Map DRAM as Normal Write-Back Cacheable instead of Normal Non-Cacheable, keeping the other attributes unchanged
- Clean and invalidate the D-Cache on each mbox call to make mbox work correctly