### PR TITLE
build: disable PIC in Embedded Swift

### DIFF
--- a/toolset.json
+++ b/toolset.json
@@ -6,6 +6,7 @@
             "-Xfrontend", "-no-allocations",
             "-Xfrontend", "-function-sections",
             "-Xfrontend", "-disable-stack-protector",
+            "-Xcc", "-fno-pic",
             "-Xlinker-driver", "-nostdlib",
             "-Xlinker-driver", "-fuse-ld=lld"
         ]


### PR DESCRIPTION
Previously, there was no way to disable PIC when compiling Swift, so it
was not possible to avoid generating the GOT section. This is now
possible thanks to swiftlang/swift#90779.
