### PR TITLE
build: replace `-no-allocations` with `-Werror HeapAllocation`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ImmutableWeakCaptures"),
     .strictMemorySafety(),
     .treatAllWarnings(as: .error),
+    .treatWarning("HeapAllocation", as: .error),
 ]
 
 let cSettings: [CSetting] = [

--- a/toolset.json
+++ b/toolset.json
@@ -4,7 +4,6 @@
         "extraCLIOptions": [
             "-enable-experimental-feature", "Embedded",
             "-enable-experimental-feature", "CodeGenerationModel=implementation",
-            "-Xfrontend", "-no-allocations",
             "-Xfrontend", "-function-sections",
             "-Xfrontend", "-disable-stack-protector",
             "-Xcc", "-fno-pic",


### PR DESCRIPTION
After https://github.com/swiftlang/swift/pull/91376, `-Werror HeapAllocation` is now equivalent to `-no-allocations`.