### PR TITLE
ci: add release build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,32 +11,53 @@ defaults:
   run:
     shell: bash -euo pipefail {0}
 jobs:
-  build-linux:
-    runs-on: ubuntu-24.04-arm
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04-arm, macos-26]
+        config: [debug, release]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        if: runner.os == 'Linux'
         with:
           path: |
             ~/.cache/org.swift.swiftpm
             ~/.swiftpm
             .build
-          key: ${{ runner.os }}-swiftpm-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-swiftpm-
+          key: ${{ runner.os }}-swiftpm-${{ matrix.config }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-${{ matrix.config }}-
+            ${{ runner.os }}-swiftpm-
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        if: runner.os == 'macOS'
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+            ~/.swiftpm
+            .build
+          key: ${{ runner.os }}-swiftpm-${{ matrix.config }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-${{ matrix.config }}-
+            ${{ runner.os }}-swiftpm-
       - run: ./.github/scripts/ci-install-swift.sh
       - run: swift --version
-      - run: swift build --triple aarch64-none-none-elf --toolset toolset.json --build-system native --explicit-target-dependency-import-check error
-  build-macos:
-    runs-on: macos-26
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - run: ./.github/scripts/ci-install-swift.sh
-      - run: swift --version
-      - run: swift build --triple aarch64-none-none-elf --toolset toolset.json --build-system native --explicit-target-dependency-import-check error
+      - run: swift package clean
+        if: matrix.config == 'release'
+      - name: Build
+        run: |
+          if [ "${{ matrix.config }}" = "release" ]; then
+            swift build -c release -Xswiftc -Osize --triple aarch64-none-none-elf --toolset toolset.json --experimental-lto-mode=full -Xswiftc -experimental-hermetic-seal-at-link --build-system native --explicit-target-dependency-import-check error
+            llvm-objcopy .build/release/Kernel -O binary .build/kernel8.img
+          else
+            swift build --triple aarch64-none-none-elf --toolset toolset.json --build-system native --explicit-target-dependency-import-check error
+            llvm-objcopy .build/debug/Kernel -O binary .build/kernel8.img
+          fi
   lint:
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -65,7 +86,7 @@ jobs:
   results:
     if: ${{ always() }}
     runs-on: ubuntu-24.04-arm
-    needs: [build-linux, build-macos, lint, yamllint, shellcheck]
+    needs: [build, lint, yamllint, shellcheck]
     steps:
       - run: exit 1
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
Also includes:

- Adding a cache step on macOS too
- Adding a check whether `llvm-objcopy` succeeds
- Unifying build-linux and build-macos
