### PR TITLE
Improve `GraphicsConsole` performance

### DIFF
--- a/Sources/KernelCore/Graphics.swift
+++ b/Sources/KernelCore/Graphics.swift
@@ -69,6 +69,47 @@ package struct Graphics<Target: RenderTarget & ~Copyable>: ~Copyable {
         }
     }
 
+    package mutating func copyRect(
+        x0: Int,
+        y0: Int,
+        x1: Int,
+        y1: Int,
+        toX dstX0: Int,
+        toY dstY0: Int,
+    ) {
+        guard x0 < x1 && y0 < y1 else { return }
+
+        let width = x1 &- x0
+        let height = y1 &- y0
+
+        let xRange =
+            if x0 < dstX0 {
+                stride(from: width &- 1, through: 0, by: -1)
+            } else {
+                stride(from: 0, through: width &- 1, by: 1)
+            }
+        let yRange =
+            if y0 < dstY0 {
+                stride(from: height &- 1, through: 0, by: -1)
+            } else {
+                stride(from: 0, through: height &- 1, by: 1)
+            }
+
+        let validX = 0..<self.width
+        let validY = 0..<self.height
+        for dy in yRange {
+            let srcY = y0 &+ dy
+            let dstY = dstY0 &+ dy
+            guard validY.contains(srcY) && validY.contains(dstY) else { continue }
+            for dx in xRange {
+                let srcX = x0 &+ dx
+                let dstX = dstX0 &+ dx
+                guard validX.contains(srcX) && validX.contains(dstX) else { continue }
+                unsafe self.target[uncheckedX: dstX, y: dstY] = self.target[uncheckedX: srcX, y: srcY]
+            }
+        }
+    }
+
     package func synchronize() {
         self.target.synchronize()
     }

--- a/Sources/KernelCore/GraphicsConsole.swift
+++ b/Sources/KernelCore/GraphicsConsole.swift
@@ -51,27 +51,35 @@ package struct GraphicsConsole<Target: RenderTarget & ~Copyable>: ~Copyable, ~Es
         if self.y < lastRow {
             self.y &+= 1
         } else {
+            var maxCol = 0
+            for row in 0..<self.rows {
+                for col in maxCol..<self.cols where self.buf[self.index(row: row, col: col)] != 0x20 {
+                    maxCol = max(col, maxCol)
+                }
+            }
+            maxCol &+= 1
+
             self.head = (self.head &+ 1) % self.rows
 
             for col in 0..<self.cols {
                 self.buf[self.index(row: lastRow, col: col)] = 0x20
             }
 
+            self.gfx.value.copyRect(
+                x0: 0,
+                y0: fontHeight,
+                x1: maxCol &* fontWidth,
+                y1: self.rows &* fontHeight,
+                toX: 0,
+                toY: 0,
+            )
             self.gfx.value.fillRect(
                 x0: 0,
-                y0: 0,
-                x1: self.cols &* fontWidth,
+                y0: lastRow &* fontHeight,
+                x1: maxCol &* fontWidth,
                 y1: self.rows &* fontHeight,
                 color: self.bgColor,
             )
-            for row in 0..<lastRow {
-                for col in 0..<self.cols {
-                    let c = self.buf[self.index(row: row, col: col)]
-                    if c != 0x20 {
-                        self.gfx.value.drawChar(c, x: col &* fontWidth, y: row &* fontHeight, color: self.fgColor)
-                    }
-                }
-            }
         }
     }
 }

--- a/Sources/KernelCore/GraphicsConsole.swift
+++ b/Sources/KernelCore/GraphicsConsole.swift
@@ -11,6 +11,7 @@ package struct GraphicsConsole<Target: RenderTarget & ~Copyable>: ~Copyable, ~Es
 
     private var gfx: MutableRef<Graphics<Target>>
     private var buf: [8192 of UInt8]  // maxCols * maxRows
+    private var head: Int
     private var x: Int
     private var y: Int
 
@@ -34,15 +35,28 @@ package struct GraphicsConsole<Target: RenderTarget & ~Copyable>: ~Copyable, ~Es
         self.fgColor = fgColor
         self.bgColor = bgColor
         self.buf = .init(repeating: 0x20)
+        self.head = 0
         self.x = 0
         self.y = 0
     }
 
+    private func index(row: Int, col: Int) -> Int {
+        let trueRow = (self.head &+ row) % self.rows
+        return trueRow &* maxCols &+ col
+    }
+
     private mutating func newLine() {
         self.x = 0
-        if self.y < self.rows &- 1 {
+        let lastRow = self.rows &- 1
+        if self.y < lastRow {
             self.y &+= 1
         } else {
+            self.head = (self.head &+ 1) % self.rows
+
+            for col in 0..<self.cols {
+                self.buf[self.index(row: lastRow, col: col)] = 0x20
+            }
+
             self.gfx.value.fillRect(
                 x0: 0,
                 y0: 0,
@@ -50,20 +64,14 @@ package struct GraphicsConsole<Target: RenderTarget & ~Copyable>: ~Copyable, ~Es
                 y1: self.rows &* fontHeight,
                 color: self.bgColor,
             )
-            for row in 0..<self.rows &- 1 {
+            for row in 0..<lastRow {
                 for col in 0..<self.cols {
-                    let c = self.buf[(row &+ 1) &* maxCols &+ col]
+                    let c = self.buf[self.index(row: row, col: col)]
                     if c != 0x20 {
                         self.gfx.value.drawChar(c, x: col &* fontWidth, y: row &* fontHeight, color: self.fgColor)
                     }
-                    self.buf[row &* maxCols &+ col] = c
                 }
             }
-            let lastRow = self.rows &- 1
-            for col in 0..<self.cols {
-                self.buf[lastRow &* maxCols &+ col] = 0x20
-            }
-            self.y = lastRow
         }
     }
 }
@@ -77,7 +85,7 @@ extension GraphicsConsole: Console where Target: ~Copyable {
             if c != 0x20 {
                 self.gfx.value.drawChar(c, x: self.x &* fontWidth, y: self.y &* fontHeight, color: self.fgColor)
             }
-            self.buf[self.y &* maxCols &+ self.x] = c
+            self.buf[self.index(row: self.y, col: self.x)] = c
             self.x &+= 1
             if self.x >= self.cols {
                 self.newLine()


### PR DESCRIPTION
Changes:

- Use the ring buffer to minimize rewriting `buf`
- Add `GraphicsConsole.copyRect`
- Use `GraphicsConsole.copyRect` to scroll the framebuffer instead of redrawing all characters